### PR TITLE
fix a typo on demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Live Demo
 
-[Live Demo Link](https://elerqsousy.github.io/Portfolio/)
+[Live Demo Link](https://elerqsousy.github.io/portfolio/)
 
 ## Authors
 


### PR DESCRIPTION
## Update demo link to project 

In this milestone:
- The project deployment has been done previously. After changing the name of the project to only contain lowercase letters the link needed to be updated.
- Updated the link to match the deployed page link.